### PR TITLE
refactor(cachyos): remove unused local variable and tighten regexp match

### DIFF
--- a/quickget
+++ b/quickget
@@ -1645,9 +1645,7 @@ function get_bunsenlabs() {
 function get_cachyos() {
     local HASH=""
     local URL=""
-    local ISO=""
-    URL="$(web_pipe "https://cachyos.org/download/" | tr '&' '\n' | grep "ISO/${EDITION}" | cut -d';' -f2)"
-    ISO="$(basename "${ISO}")"
+    URL="$(web_pipe "https://cachyos.org/download/" | tr '&' '\n' | grep -m 1 -o -E "https://[[:alnum:]]+\.cachyos\.org/ISO/${EDITION}/[[:digit:]]+/.*\.iso")"
     HASH=$(web_pipe "${URL}.sha256" | cut -d' ' -f1)
     echo "${URL} ${HASH}"
 }


### PR DESCRIPTION
# Description

Removes the unused ISO variable and uses grep alone to extract the URL per my review suggestions.

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
